### PR TITLE
feat: compatibilité WordPress 7.0 (Font Library + customCSS)

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -110,7 +110,9 @@ class Block
         'align' => false,
         'align_text' => false,
         'align_content' => false,
-        'jsx' => false
+        'jsx' => false,
+        // Désactive le champ « CSS additionnel » par bloc ajouté par WordPress 7.0.
+        'customCSS' => false,
     ];
 
     /**

--- a/src/Hooks/FontLibraryHooks.php
+++ b/src/Hooks/FontLibraryHooks.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\WP\Extensions\Hooks;
+
+/**
+ * Désactive la Font Library introduite par WordPress 7.0.
+ *
+ * Compatible WP < 7 : sans Font Library, remove_submenu_page() est un no-op et
+ * $pagenow ne vaut jamais 'font-library.php', donc ces hooks sont sans effet.
+ */
+class FontLibraryHooks
+{
+    /**
+     * Retire l'entrée de menu « Polices » (Font Library, WP 7.0) sous Apparence.
+     */
+    public static function removeFontLibraryMenu(): void
+    {
+        remove_submenu_page('themes.php', 'font-library.php');
+    }
+
+    /**
+     * Bloque l'accès direct à la Font Library par URL (wp-admin/font-library.php).
+     */
+    public static function blockFontLibraryAccess(): void
+    {
+        global $pagenow;
+
+        if ('font-library.php' === $pagenow) {
+            wp_safe_redirect(admin_url());
+            exit;
+        }
+    }
+}

--- a/src/Providers/AdminServiceProvider.php
+++ b/src/Providers/AdminServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Adeliom\WP\Extensions\Providers;
 
 use Adeliom\WP\Extensions\Admin\AbstractAdmin;
+use Adeliom\WP\Extensions\Hooks\FontLibraryHooks;
 use Rareloop\Lumberjack\Config;
 use Rareloop\Lumberjack\Providers\ServiceProvider;
 use ReflectionClass;
@@ -21,6 +22,10 @@ class AdminServiceProvider extends ServiceProvider
      */
     public function boot(Config $config): void
     {
+        // WordPress 7.0 : désactivation de la Font Library (menu + accès direct).
+        add_action('admin_menu', [FontLibraryHooks::class, "removeFontLibraryMenu"], 999, 0);
+        add_action('admin_init', [FontLibraryHooks::class, "blockFontLibraryAccess"], 10, 0);
+
         $adminPath = $this->app->basePath() . "/app/Admin";
 
         foreach ($this->getDirContents($adminPath) as $file) {


### PR DESCRIPTION
## Contexte

Adaptation de `lumberjack-extensions` pour WordPress 7.0, qui introduit deux nouveautés que l'on souhaite désactiver par défaut sur les projets Adeliom. Portage de la même logique que [lumberjack-admin#3](https://github.com/agence-adeliom/lumberjack-admin/pull/3), adaptée à l'architecture de cette lib (namespaces `Adeliom\WP\Extensions`, providers `boot()`).

## Changements

- **Désactivation de la Font Library** : nouvelle classe `Hooks\FontLibraryHooks`, câblée dans `AdminServiceProvider::boot()` — retrait de l'entrée de menu « Polices » sous Apparence (`admin_menu`, priorité 999) et blocage de l'accès direct à `wp-admin/font-library.php` (`admin_init`).
- **Désactivation du « CSS additionnel » par bloc** : ajout de `'customCSS' => false` dans les `$supports` par défaut de `Blocks\Block`.

## Rétro-compatibilité

Sans effet sur WordPress < 7.0 : `remove_submenu_page()` est un no-op si le menu n'existe pas, et `$pagenow` ne vaut jamais `font-library.php`.

## Tests

Validé sur le projet **schmidt-cuisinella_merchandising-book** (WordPress 7.0, DDEV), en patchant le vendor :
- classe autoloadée, hooks enregistrés (`admin_menu` 999, `admin_init` 10) ;
- `Block::$supports['customCSS'] === false` ;
- suppression effective du sous-menu `font-library.php` vérifiée.